### PR TITLE
Adding mpileup usage to analyse bams for base percentages

### DIFF
--- a/piranha/analysis/consensus_functions.py
+++ b/piranha/analysis/consensus_functions.py
@@ -4,6 +4,7 @@ import collections
 from Bio import SeqIO
 import csv
 from itertools import groupby, count
+import pysam
 # from cigar import Cigar
 
 from piranha.utils.config import *

--- a/piranha/analysis/consensus_functions.py
+++ b/piranha/analysis/consensus_functions.py
@@ -146,7 +146,12 @@ def non_ref_prcnt_calc(pos,pileup_dict,ref_dict):
             if key != "Position":
                 total += pileup_dict[key]
         ref_count = pileup_dict[ref_base]
-        non_ref_prcnt = round((100 - ((ref_count / total) * 100)), 2)
+        if (total == 0):
+            non_ref_prcnt = 0
+        elif (ref_count == 0):
+            non_ref_prcnt = 100
+        else:
+            non_ref_prcnt = round((100 - ((ref_count / total) * 100)), 2)
 
     return non_ref_prcnt
 
@@ -163,8 +168,6 @@ def pileupper(bamfile,ref_dict,base_q=13):
             if not pileupread.is_del and not pileupread.is_refskip:
                 # query position is None if is_del or is_refskip is set.
                 counts_list = []
-                #print(pileupread.alignment.query_position)
-                #print(pileupread.alignment.query_sequence[pileupread.query_position])
                 if pileupread.alignment.query_sequence[pileupread.query_position] == "A":
                     A_counter += 1
                 elif pileupread.alignment.query_sequence[pileupread.query_position] == "G":
@@ -182,7 +185,7 @@ def pileupper(bamfile,ref_dict,base_q=13):
         pileup_dict["G reads"] = G_counter
         pileup_dict["- reads"] = del_counter
         pileup_dict["Percentage"] = non_ref_prcnt_calc(pileupcolumn.pos,pileup_dict,ref_dict)
-        pileup_dict["ref_base"] = ref_dict[pileupcolumn.pos]
+        pileup_dict["Ref base"] = ref_dict[pileupcolumn.pos]
         variation_info.append(pileup_dict)
 
     return (variation_info)

--- a/piranha/data/english_barcode_report.mako
+++ b/piranha/data/english_barcode_report.mako
@@ -608,7 +608,8 @@
                                             {"field": "C reads", "type": "nominal"},
                                             {"field": "G reads", "type": "nominal"},
                                             {"field": "T reads", "type": "nominal"},
-                                            {"field": "- reads", "type": "nominal"}
+                                            {"field": "- reads", "type": "nominal"},
+                                            {"field": "Ref base", "type": "nominal"}
                                           ],
                               "color": {"field":"snp_type","type":"nominal","scale": {"range": {"field": "colour"}}},
                               "size": {"field":"size",

--- a/piranha/scripts/variation.smk
+++ b/piranha/scripts/variation.smk
@@ -71,7 +71,7 @@ rule sam_to_indels:
                 gofasta sam indels --threshold {config[min_read_depth]} -s {input.sam_cns:q} --insertions-out {output.ins:q} --deletions-out {output.dels:q} 
                 """)
 
-
+            
 rule get_variation_info:
     input:
         ref = expand(rules.files.params.ref, reference=REFERENCES),
@@ -84,14 +84,13 @@ rule get_variation_info:
         for reference in REFERENCES:
             if "Sabin" in reference:
                 ref = os.path.join(config[KEY_TEMPDIR],"reference_groups",f"{reference}.reference.fasta")
+                bamfile = os.path.join(config[KEY_TEMPDIR],"reference_analysis",f"{reference}","mapped.sorted.bam")
             else:
                 ref = os.path.join(config[KEY_TEMPDIR],"reference_analysis",f"{reference}","medaka","consensus.fasta")
+                bamfile = os.path.join(config[KEY_TEMPDIR],"reference_analysis",f"{reference}","mapped_cns.sorted.bam")
 
-            bamfile = os.path.join(config[KEY_TEMPDIR],"reference_analysis",f"{reference}","mapped.sorted.bam")
+            shell(f"samtools faidx {ref}")
 
-            shell("""
-                samtools faidx {input.ref}
-                """)
             ref_dict = ref_dict_maker(ref)
             var_dict = pileupper(bamfile,ref_dict)
             variation_dict[reference] = var_dict


### PR DESCRIPTION
Added some functions to use pysam's mpileup instead of gofasta for analysing the base composition at every position for each set of produced bam files.