### PR TITLE
Epi2me debug

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -15,7 +15,7 @@
       "properties": {
         "barcodes_csv": {
           "type": "string",
-          "format": "path",
+          "format": "file-path",
           "title": "Barcodes",
           "description": "A CSV file with barcode and sample columns.",
           "help_text": ".",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -23,7 +23,7 @@
         },
         "run_dir": {
           "type": "string",
-          "format": "path",
+          "format": "directory-path",
           "title": "Run directory",
           "description": "A directory containing a directory of fastq for a each barcode in a run.",
           "help_text": "A directory containing subdirectories of fastq files as created by MinKNOW.",
@@ -66,7 +66,7 @@
       "properties": {
         "config": {
           "type": "string",
-          "format": "path",
+          "format": "file-path",
           "title": "Config file",
           "description": "A config file with parameters for piranha."
         },


### PR DESCRIPTION
It appears that for the epi2me Nextflow schema with Windows OS, you need to specify that your input format is specifically "file-path" when looking for a single file input, whereas "path" works fine for Mac.